### PR TITLE
fix some problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ At present, this program supports the following download methods:
 
 **Note: aria2 itself does not support HTTP POST download links, while onedrive folder package download is HTTP POST download links, so this program will not support onedrive folder package download**
 
+## Output file list
+
+input this command then you can get file list in list.txt
+
+``` bash
+python main.py > list.txt
+```
+
+It maybe output gibberish in powershell, you can input this command before to fix
+
+``` bash
+[System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+```
+
 ## Without password for shared links
 
 Take this download link as an example:

--- a/docs/Readme_zh-cn.md
+++ b/docs/Readme_zh-cn.md
@@ -21,6 +21,20 @@ pyppeteer==0.2.5
 
 **注意：Aria2本身不支持HTTP POST型的下载链接，而OneDrive文件夹打包下载为HTTP POST型的下载链接，所以本程序将不会支持OneDrive文件夹打包下载**
 
+## 输出文件列表
+
+使用以下命令输出文件列表到list.txt
+
+``` bash
+python main.py > list.txt
+```
+
+使用powershell运行此命令可能会输出乱码, 先运行以下命令即可修复
+
+``` bash
+[System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+```
+
 ## 无密码的链接
 
 以 https://gitaccuacnz2-my.sharepoint.com/:f:/g/personal/mail_finderacg_com/EheQwACFhe9JuGUn4hlg9esBsKyk5jp9-Iz69kqzLLF5Xw?e=FG7SHh 这个下载链接为例


### PR DESCRIPTION
修复以下问题:
1. 进入二级目录时, 文件id会重置为1导致id错误:  [图例](https://pic.rmb.bdstatic.com/bjh/1e5bc63da1e46c6e5857d98b6fb0e51b.png)
2. 在win平台的cmd/powershell运行时, 使用输出重定向会导致print函数报编码错误: UnicodeEncodeError: 'gbk' codec can't encode character